### PR TITLE
Redesign destinations page with interactive tabs and cards

### DIFF
--- a/src/pages/Destinations.tsx
+++ b/src/pages/Destinations.tsx
@@ -89,7 +89,7 @@ const DestinationsPage = () => {
                     <MapPin className="h-4 w-4" /> {activeDestination.region}
                   </div>
 
-                  <p className="mt-3 line-clamp-2 text-sm text-muted-foreground">
+                  <p className="mt-3 text-sm text-muted-foreground">
                     {pkg.description}
                   </p>
 

--- a/src/pages/Destinations.tsx
+++ b/src/pages/Destinations.tsx
@@ -1,93 +1,113 @@
+import { useMemo, useState } from "react";
 import Navigation from "@/components/Navigation";
 import Footer from "@/components/Footer";
 import { Button } from "@/components/ui/button";
-import { Card } from "@/components/ui/card";
+import { Card, CardContent } from "@/components/ui/card";
 import { destinationIconMap, destinations } from "@/data/destinations";
-import { ArrowRight, MapPinned } from "lucide-react";
+import { Calendar, MapPin, Star } from "lucide-react";
 import { Link } from "react-router-dom";
 
 const DestinationsPage = () => {
+  const [activeSlug, setActiveSlug] = useState(destinations[0]?.slug ?? "");
+  const activeDestination = useMemo(
+    () => destinations.find((d) => d.slug === activeSlug) ?? destinations[0],
+    [activeSlug]
+  );
+
   return (
     <div className="min-h-screen bg-background text-foreground">
       <Navigation />
 
       <main className="pt-24 pb-20">
-        <section className="container mx-auto px-4 text-center">
-          <div className="mx-auto max-w-3xl space-y-4">
-            <span className="inline-flex items-center gap-2 rounded-full bg-primary/10 px-4 py-2 text-sm font-medium text-primary">
-              <MapPinned className="h-4 w-4" />
-              Explore destinations crafted for storytellers
-            </span>
-            <h1 className="text-4xl font-bold tracking-tight sm:text-5xl">
-              Curated journeys across the Himalayas
-            </h1>
-            <p className="text-lg text-muted-foreground">
-              Choose from high-altitude odysseys, monastery circuits, rainforest trails, and cultural immersions designed by our expedition experts.
-            </p>
+        {/* Category Tabs */}
+        <section className="container mx-auto px-4">
+          <div className="flex items-center justify-between gap-3">
+            <h1 className="text-2xl font-semibold sm:text-3xl">Choose a destination</h1>
           </div>
-        </section>
-
-        <section className="container mx-auto px-4 mt-16">
-          <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
-            {destinations.map((destination) => {
-              const Icon = destinationIconMap[destination.icon];
-
+          <div className="mt-4 flex gap-3 overflow-x-auto py-2">
+            {destinations.map((d) => {
+              const Icon = destinationIconMap[d.icon];
+              const active = d.slug === activeSlug;
               return (
-                <Card
-                  key={destination.slug}
-                  className="group relative overflow-hidden border border-border/70 bg-card/80 backdrop-blur rounded-xl shadow-lg transition-all duration-300 hover:-translate-y-1 hover:border-primary/60"
+                <button
+                  key={d.slug}
+                  onClick={() => setActiveSlug(d.slug)}
+                  className={[
+                    "shrink-0 inline-flex items-center gap-2 rounded-full border px-4 py-2 text-sm font-medium transition-all",
+                    active
+                      ? "bg-primary text-primary-foreground border-primary"
+                      : "bg-background/80 text-foreground border-border hover:bg-accent/40",
+                  ].join(" ")}
                 >
-                  <Link to={`/destinations/${destination.slug}`} className="flex h-full flex-col p-6 text-left">
-                    <div className="mb-6 flex items-start justify-between gap-4">
-                      <div className="flex items-center gap-3">
-                        <div className="rounded-full bg-primary/10 p-3 text-primary transition-colors group-hover:bg-primary/20">
-                          <Icon className="h-5 w-5" />
-                        </div>
-                        <div>
-                          <h2 className="text-xl font-semibold text-foreground">
-                            {destination.name}
-                          </h2>
-                          <p className="text-sm text-muted-foreground">
-                            {destination.region}
-                          </p>
-                        </div>
-                      </div>
-                      {destination.badge && (
-                        <span className="rounded-full bg-orange-500 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-white shadow">
-                          {destination.badge}
-                        </span>
-                      )}
-                    </div>
-
-                    <p className="flex-1 text-sm text-muted-foreground leading-relaxed">
-                      {destination.tagline}
-                    </p>
-
-                    <div className="mt-6 flex items-center justify-between text-sm font-medium">
-                      <span className="text-primary">View experiences</span>
-                      <ArrowRight className="h-4 w-4 text-primary transition-transform group-hover:translate-x-1" />
-                    </div>
-                  </Link>
-                </Card>
+                  <Icon className="h-4 w-4" />
+                  {d.name}
+                </button>
               );
             })}
           </div>
         </section>
 
-        <section className="container mx-auto px-4 mt-20">
-          <div className="rounded-3xl bg-gradient-to-r from-primary/10 via-primary/5 to-secondary/10 p-10 text-center">
-            <h2 className="text-3xl font-semibold text-foreground">
-              Need something more custom?
-            </h2>
-            <p className="mt-3 text-muted-foreground">
-              Tell us the adventure you dream about and our travel designers will craft an exclusive itinerary for your crew.
-            </p>
-            <Button asChild size="lg" className="mt-6">
-              <Link to="/" className="inline-flex items-center gap-2">
-                Talk to an expert
-                <ArrowRight className="h-4 w-4" />
-              </Link>
-            </Button>
+        {/* Listing header */}
+        <section className="container mx-auto px-4 mt-8">
+          <h2 className="text-3xl font-bold tracking-tight sm:text-4xl">
+            Tours in {activeDestination.name}
+          </h2>
+          <p className="mt-2 text-muted-foreground">
+            Handpicked experiences with transparent pricing and honest ratings.
+          </p>
+        </section>
+
+        {/* Packages grid */}
+        <section className="container mx-auto px-4 mt-8">
+          <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+            {activeDestination.packages.map((pkg) => (
+              <Card
+                key={pkg.name}
+                className="group overflow-hidden border border-border/70 bg-card/80 backdrop-blur rounded-xl shadow-lg transition-all duration-300 hover:-translate-y-1 hover:border-primary/60"
+              >
+                {pkg.image && (
+                  <div className="relative h-56 w-full overflow-hidden">
+                    <img
+                      src={pkg.image}
+                      alt={pkg.name}
+                      className="h-full w-full object-cover transition-transform duration-500 group-hover:scale-105"
+                    />
+                    <span className="absolute left-4 top-4 inline-flex items-center gap-1 rounded-full bg-white/90 px-3 py-1 text-xs font-semibold text-foreground shadow">
+                      <Calendar className="h-3.5 w-3.5" /> {pkg.duration}
+                    </span>
+                    <span className="absolute right-4 top-4 inline-flex items-center gap-1 rounded-full bg-emerald-500 px-2.5 py-1 text-xs font-semibold text-white shadow">
+                      <Star className="h-3.5 w-3.5 fill-white" /> {pkg.rating}
+                    </span>
+                  </div>
+                )}
+
+                <CardContent className="p-5">
+                  <h3 className="text-lg font-semibold leading-snug">
+                    {pkg.name}
+                  </h3>
+                  <div className="mt-1 flex items-center gap-2 text-sm text-muted-foreground">
+                    <MapPin className="h-4 w-4" /> {activeDestination.region}
+                  </div>
+
+                  <p className="mt-3 line-clamp-2 text-sm text-muted-foreground">
+                    {pkg.description}
+                  </p>
+
+                  <div className="mt-5 flex items-end justify-between gap-3">
+                    <div>
+                      {pkg.oldPrice && (
+                        <p className="text-xs text-muted-foreground line-through">{pkg.oldPrice}</p>
+                      )}
+                      <p className="text-xl font-semibold text-primary">{pkg.price} <span className="text-xs font-normal text-muted-foreground">/ adult</span></p>
+                    </div>
+
+                    <Button asChild variant="outline" className="whitespace-nowrap">
+                      <Link to={`/destinations/${activeDestination.slug}`}>View details</Link>
+                    </Button>
+                  </div>
+                </CardContent>
+              </Card>
+            ))}
           </div>
         </section>
       </main>

--- a/src/pages/Destinations.tsx
+++ b/src/pages/Destinations.tsx
@@ -4,7 +4,7 @@ import Footer from "@/components/Footer";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { destinationIconMap, destinations } from "@/data/destinations";
-import { ArrowRight, Calendar, MapPin, Star } from "lucide-react";
+import { ArrowRight, Calendar, MapPin, MapPinned, Star } from "lucide-react";
 import { Link } from "react-router-dom";
 
 const DestinationsPage = () => {
@@ -19,6 +19,22 @@ const DestinationsPage = () => {
       <Navigation />
 
       <main className="pt-24 pb-20">
+        {/* Hero */}
+        <section className="container mx-auto px-4 text-center">
+          <div className="mx-auto max-w-3xl space-y-4">
+            <span className="inline-flex items-center gap-2 rounded-full bg-primary/10 px-4 py-2 text-sm font-medium text-primary">
+              <MapPinned className="h-4 w-4" />
+              Explore destinations crafted for storytellers
+            </span>
+            <h1 className="text-4xl font-bold tracking-tight sm:text-5xl">
+              Curated journeys across the Himalayas
+            </h1>
+            <p className="text-lg text-muted-foreground">
+              Choose from high-altitude odysseys, monastery circuits, rainforest trails, and cultural immersions designed by our expedition experts.
+            </p>
+          </div>
+        </section>
+
         {/* Category Tabs */}
         <section className="container mx-auto px-4">
           <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">

--- a/src/pages/Destinations.tsx
+++ b/src/pages/Destinations.tsx
@@ -4,7 +4,7 @@ import Footer from "@/components/Footer";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { destinationIconMap, destinations } from "@/data/destinations";
-import { Calendar, MapPin, Star } from "lucide-react";
+import { ArrowRight, Calendar, MapPin, Star } from "lucide-react";
 import { Link } from "react-router-dom";
 
 const DestinationsPage = () => {
@@ -21,10 +21,20 @@ const DestinationsPage = () => {
       <main className="pt-24 pb-20">
         {/* Category Tabs */}
         <section className="container mx-auto px-4">
-          <div className="flex items-center justify-between gap-3">
-            <h1 className="text-2xl font-semibold sm:text-3xl">Choose a destination</h1>
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+            <div>
+              <span className="text-sm font-semibold uppercase tracking-wide text-primary">Explore</span>
+              <h2 className="mt-1 text-3xl font-semibold">Pick a region to uncover handpicked tours</h2>
+              <p className="mt-2 max-w-xl text-sm text-muted-foreground">
+                Switch between regions to preview signature expeditions, price drops, and ratings in one glance.
+              </p>
+            </div>
+            <Link to="/destinations" className="flex items-center gap-2 text-sm font-semibold text-primary">
+              View all destinations
+              <ArrowRight className="h-4 w-4" />
+            </Link>
           </div>
-          <div className="mt-4 flex gap-3 overflow-x-auto py-2">
+          <div className="mt-8 flex gap-3 overflow-x-auto pb-2">
             {destinations.map((d) => {
               const Icon = destinationIconMap[d.icon];
               const active = d.slug === activeSlug;
@@ -33,14 +43,19 @@ const DestinationsPage = () => {
                   key={d.slug}
                   onClick={() => setActiveSlug(d.slug)}
                   className={[
-                    "shrink-0 inline-flex items-center gap-2 rounded-full border px-4 py-2 text-sm font-medium transition-all",
+                    "group flex min-w-[180px] items-center gap-3 rounded-full border px-5 py-3 text-sm font-medium transition-all",
                     active
-                      ? "bg-primary text-primary-foreground border-primary"
-                      : "bg-background/80 text-foreground border-border hover:bg-accent/40",
+                      ? "border-primary/40 bg-primary text-primary-foreground shadow"
+                      : "border-border/60 bg-muted/60 text-muted-foreground hover:border-primary/30 hover:bg-primary/10 hover:text-primary",
                   ].join(" ")}
                 >
-                  <Icon className="h-4 w-4" />
-                  {d.name}
+                  <span className="rounded-full bg-white/20 p-2 text-current transition-colors group-hover:bg-white/30">
+                    <Icon className="h-4 w-4" />
+                  </span>
+                  <div className="text-left">
+                    <span className="block text-sm font-semibold">{d.name}</span>
+                    <span className="text-xs text-muted-foreground">{d.tagline}</span>
+                  </div>
                 </button>
               );
             })}
@@ -49,12 +64,17 @@ const DestinationsPage = () => {
 
         {/* Listing header */}
         <section className="container mx-auto px-4 mt-8">
-          <h2 className="text-3xl font-bold tracking-tight sm:text-4xl">
-            Tours in {activeDestination.name}
-          </h2>
-          <p className="mt-2 text-muted-foreground">
-            Handpicked experiences with transparent pricing and honest ratings.
-          </p>
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+            <div>
+              <h2 className="text-3xl font-bold tracking-tight sm:text-4xl">Tours in {activeDestination.name}</h2>
+              <p className="mt-2 max-w-2xl text-sm text-muted-foreground">{activeDestination.summary}</p>
+            </div>
+            <div className="flex flex-wrap gap-2 text-xs font-medium text-muted-foreground">
+              <span className="rounded-full bg-muted px-3 py-1">Best time: {activeDestination.quickFacts.bestTime}</span>
+              <span className="rounded-full bg-muted px-3 py-1">Start point: {activeDestination.quickFacts.startPoint}</span>
+              <span className="rounded-full bg-muted px-3 py-1">Style: {activeDestination.quickFacts.travelStyle}</span>
+            </div>
+          </div>
         </section>
 
         {/* Packages grid */}
@@ -63,47 +83,65 @@ const DestinationsPage = () => {
             {activeDestination.packages.map((pkg) => (
               <Card
                 key={pkg.name}
-                className="group overflow-hidden border border-border/70 bg-card/80 backdrop-blur rounded-xl shadow-lg transition-all duration-300 hover:-translate-y-1 hover:border-primary/60"
+                className="group flex h-full flex-col overflow-hidden border border-border/60 bg-card/90 shadow-lg transition-all duration-300 hover:-translate-y-1 hover:border-primary/60"
               >
                 {pkg.image && (
-                  <div className="relative h-56 w-full overflow-hidden">
+                  <div className="relative h-48 w-full overflow-hidden">
                     <img
                       src={pkg.image}
                       alt={pkg.name}
-                      className="h-full w-full object-cover transition-transform duration-500 group-hover:scale-105"
+                      className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-105"
+                      loading="lazy"
                     />
                     <span className="absolute left-4 top-4 inline-flex items-center gap-1 rounded-full bg-white/90 px-3 py-1 text-xs font-semibold text-foreground shadow">
                       <Calendar className="h-3.5 w-3.5" /> {pkg.duration}
                     </span>
                     <span className="absolute right-4 top-4 inline-flex items-center gap-1 rounded-full bg-emerald-500 px-2.5 py-1 text-xs font-semibold text-white shadow">
-                      <Star className="h-3.5 w-3.5 fill-white" /> {pkg.rating}
+                      <Star className="h-3.5 w-3.5 fill-white" /> {pkg.rating.toFixed ? pkg.rating.toFixed(1) : pkg.rating}
+                      <span className="text-white/80">({pkg.reviews})</span>
                     </span>
                   </div>
                 )}
 
-                <CardContent className="p-5">
-                  <h3 className="text-lg font-semibold leading-snug">
-                    {pkg.name}
-                  </h3>
-                  <div className="mt-1 flex items-center gap-2 text-sm text-muted-foreground">
+                <CardContent className="p-6">
+                  <div className="flex items-start justify-between gap-4">
+                    <div>
+                      <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">{pkg.duration}</p>
+                      <h3 className="mt-1 text-lg font-semibold leading-snug">{pkg.name}</h3>
+                    </div>
+                    <div className="hidden sm:flex items-center gap-1 rounded-full bg-emerald-100 px-2 py-1 text-xs font-semibold text-emerald-700">
+                      <Star className="h-3.5 w-3.5 fill-current" />
+                      <span>{pkg.rating.toFixed ? pkg.rating.toFixed(1) : pkg.rating}</span>
+                      <span className="text-muted-foreground">({pkg.reviews})</span>
+                    </div>
+                  </div>
+
+                  <div className="mt-2 flex items-center gap-2 text-sm text-muted-foreground">
                     <MapPin className="h-4 w-4" /> {activeDestination.region}
                   </div>
 
-                  <p className="mt-3 text-sm text-muted-foreground">
-                    {pkg.description}
-                  </p>
+                  <p className="mt-3 text-sm text-muted-foreground">{pkg.description}</p>
 
-                  <div className="mt-5 flex items-end justify-between gap-3">
-                    <div>
+                  <div className="mt-5 flex flex-wrap items-baseline justify-between gap-3">
+                    <div className="flex items-baseline gap-2">
+                      <span className="text-xl font-semibold text-foreground">{pkg.price}</span>
                       {pkg.oldPrice && (
-                        <p className="text-xs text-muted-foreground line-through">{pkg.oldPrice}</p>
+                        <span className="text-sm text-muted-foreground line-through">{pkg.oldPrice}</span>
                       )}
-                      <p className="text-xl font-semibold text-primary">{pkg.price} <span className="text-xs font-normal text-muted-foreground">/ adult</span></p>
+                      {pkg.badge && (
+                        <span className="rounded-full bg-emerald-100 px-2 py-1 text-[11px] font-semibold text-emerald-700">{pkg.badge}</span>
+                      )}
                     </div>
 
-                    <Button asChild variant="outline" className="whitespace-nowrap">
-                      <Link to={`/destinations/${activeDestination.slug}`}>View details</Link>
-                    </Button>
+                    <div className="flex w-full gap-2 sm:w-auto">
+                      <Button asChild variant="secondary" className="flex-1 sm:flex-none">
+                        <Link to={`/destinations/${activeDestination.slug}`} state={{ focusPackage: pkg.name }}>
+                          View itinerary
+                          <ArrowRight className="h-4 w-4" />
+                        </Link>
+                      </Button>
+                      <Button variant="outline" className="flex-1 sm:flex-none">Request callback</Button>
+                    </div>
                   </div>
                 </CardContent>
               </Card>


### PR DESCRIPTION
## Purpose

The user requested to redesign the destinations page to match a specific layout shown in a screenshot. They wanted the destination page to display content differently when clicked, referencing a GitHub repository (https://github.com/shivam13669/ST11) as the desired design pattern.

## Code changes

- **Added interactive destination tabs**: Implemented state management with `useState` and `useMemo` to track active destination selection
- **Redesigned page layout**: 
  - Added hero section with improved styling
  - Created tabbed navigation for destinations with icons and descriptions
  - Added detailed listing header showing active destination info
- **Enhanced destination cards**: 
  - Replaced simple cards with detailed package cards including images, ratings, pricing, and duration
  - Added interactive elements like star ratings, badges, and action buttons
  - Implemented responsive grid layout for package display
- **Improved UI components**: Added new imports for `CardContent`, `Calendar`, `MapPin`, and `Star` icons
- **Added dynamic content**: Each destination now shows its packages with detailed information including images, ratings, prices, and descriptions
- **Enhanced navigation**: Added "View itinerary" and "Request callback" buttons for each package

The page now provides an interactive experience where users can switch between destinations via tabs and view detailed package information in a card-based layout.To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1`

🔗 [Edit in Builder.io](https://builder.io/app/projects/64d918a1e4484c5fbcd566d0b902f484/neon-works)

👀 [Preview Link](https://64d918a1e4484c5fbcd566d0b902f484-neon-works.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>64d918a1e4484c5fbcd566d0b902f484</projectId>-->
<!--<branchName>neon-works</branchName>-->